### PR TITLE
Software Update 2021.05.21.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
 
   gateway-config:
     image: "nebraltd/hm-config:1b4f51c0381bdcb87e9c43cf78af8e971315e006"
-    privileged: true
+    # privileged: true
     network_mode: "host"
     cap_add:
             - NET_ADMIN

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:7006d88b715f780779d76b277bf098b680c9ca5f"
+    image: "nebraltd/hm-config:a232b402a923b30917ad19bebe6bfbf7dd3d3583"
     privileged: true
     network_mode: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:a481ffda6f9044c1ea07424c4994bc37ad45e06c"
+    image: "nebraltd/hm-miner:d2766cb5fc9f8300b8410f1396a252e0f578c694"
     ports:
       - "44158:44158/tcp"
       - "1680:1680/udp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:979838c2da2caa0bbc88695ca8bd64cbafffbce2"
+    image: "nebraltd/hm-config:b68b8679f6815e4f928c2537cc300a7e63464f34"
     privileged: true
     network_mode: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,9 +33,13 @@ services:
     # privileged: true
     network_mode: "host"
     cap_add:
-            - NET_ADMIN
+      - NET_ADMIN
+      - SYS_RAWIO
     volumes:
       - 'miner-storage:/var/data'
+    devices:
+      - "/dev/i2c-1:/dev/i2c-1"
+      - "/dev/mem:/dev/mem"
     environment:
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:036573d3535ff49ac688fef8f52018c4de6b84f0"
+    image: "nebraltd/hm-config:3320c2542a4ee3cd2cd72b7d513333903c2e5671"
     privileged: true
     network_mode: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,16 +30,12 @@ services:
 
   gateway-config:
     image: "nebraltd/hm-config:1b4f51c0381bdcb87e9c43cf78af8e971315e006"
-    # privileged: true
+    privileged: true
     network_mode: "host"
     cap_add:
-      - NET_ADMIN
-      - SYS_RAWIO
+            - NET_ADMIN
     volumes:
       - 'miner-storage:/var/data'
-    devices:
-      - "/dev/i2c-1:/dev/i2c-1"
-      - "/dev/mem:/dev/mem"
     environment:
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:ba7c53af0027fd67412764de6d3ba12d3023dc8e"
+    image: "nebraltd/hm-config:e4ea4042402776e400dfa6c20ab7ab783d236584"
     privileged: true
     network_mode: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:3320c2542a4ee3cd2cd72b7d513333903c2e5671"
+    image: "nebraltd/hm-config:979838c2da2caa0bbc88695ca8bd64cbafffbce2"
     privileged: true
     network_mode: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:e4ea4042402776e400dfa6c20ab7ab783d236584"
+    image: "nebraltd/hm-config:1b4f51c0381bdcb87e9c43cf78af8e971315e006"
     privileged: true
     network_mode: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:a232b402a923b30917ad19bebe6bfbf7dd3d3583"
+    image: "nebraltd/hm-config:ba7c53af0027fd67412764de6d3ba12d3023dc8e"
     privileged: true
     network_mode: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:b68b8679f6815e4f928c2537cc300a7e63464f34"
+    image: "nebraltd/hm-config:7006d88b715f780779d76b277bf098b680c9ca5f"
     privileged: true
     network_mode: "host"
     cap_add:


### PR DESCRIPTION
This software update will do the following:

- Updates the helium miner to the latest version.
- Fixes an issue where the variant names were not showing correctly in the app
- Fixes diagnostics system in BT app
- Does some other improvements to the configuration file handling code.