### PR TITLE
Software Update 2021.05.24.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:718fcd3ff14945651512ae5ae9a55a94158ef20b"
+    image: "nebraltd/hm-diag:e0a3f495907ed14506fe06fc0502b8ac01f1dd0a"
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,24 +3,23 @@ version: '2'
 services:
 
   gateway-config:
-    environment:
-      - FIRMWAREVERSION=2021.05.24.1
-    image: "nebraltd/hm-config:60e384f5a2c99f200c149014de42086547578db8"
-    privileged: true
-    network_mode: "host"
-    cap_add:
-            - NET_ADMIN
-    volumes:
-      - 'miner-storage:/var/data'
-    environment:
-      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
-    labels:
-      io.balena.features.dbus: '1'
-      io.balena.features.sysfs: '1'
-      io.balena.features.kernel-modules: '1'
-      io.balena.features.supervisor-api: '1'
-    stop_signal: SIGINT
-
+  image: "nebraltd/hm-config:3db6baccd78b0ac1f9ad767b3043c59c90055148"
+  environment:
+    - 'FIRMWAREVERSION=2021.05.24.1'
+    - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
+  privileged: true
+  network_mode: "host"
+  cap_add:
+    - NET_ADMIN
+  volumes:
+    - 'miner-storage:/var/data'
+  labels:
+    io.balena.features.dbus: '1'
+    io.balena.features.sysfs: '1'
+    io.balena.features.kernel-modules: '1'
+    io.balena.features.supervisor-api: '1'
+  stop_signal: SIGINT
+  
   packet-forwarder:
     image: "nebraltd/hm-pktfwd:d8001d3c03b11e9944f71e6e748026d57476590d"
     privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:e0a3f495907ed14506fe06fc0502b8ac01f1dd0a"
+    image: "nebraltd/hm-diag:5401452d802024293387ba494bae432b89fe9ddd"
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,25 @@
 version: '2'
 
 services:
+  
+  gateway-config:
+    environment:
+    - FIRMWARE=1
+    image: "nebraltd/hm-config:0b0e6cbe7242e1b1dfae15a76d8c79839ad8b4b2"
+    privileged: true
+    network_mode: "host"
+    cap_add:
+            - NET_ADMIN
+    volumes:
+      - 'miner-storage:/var/data'
+    environment:
+      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
+    labels:
+      io.balena.features.dbus: '1'
+      io.balena.features.sysfs: '1'
+      io.balena.features.kernel-modules: '1'
+      io.balena.features.supervisor-api: '1'
+    stop_signal: SIGINT
 
   packet-forwarder:
     image: "nebraltd/hm-pktfwd:d8001d3c03b11e9944f71e6e748026d57476590d"
@@ -27,23 +46,6 @@ services:
       io.balena.features.dbus: '1'
       # io.balena.features.sysfs: '1'
       # io.balena.features.kernel-modules: '1'
-
-  gateway-config:
-    image: "nebraltd/hm-config:0b0e6cbe7242e1b1dfae15a76d8c79839ad8b4b2"
-    privileged: true
-    network_mode: "host"
-    cap_add:
-            - NET_ADMIN
-    volumes:
-      - 'miner-storage:/var/data'
-    environment:
-      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
-    labels:
-      io.balena.features.dbus: '1'
-      io.balena.features.sysfs: '1'
-      io.balena.features.kernel-modules: '1'
-      io.balena.features.supervisor-api: '1'
-    stop_signal: SIGINT
 
   diagnostics:
     image: "nebraltd/hm-diag:718fcd3ff14945651512ae5ae9a55a94158ef20b"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
 
   gateway-config:
     environment:
-    - FIRMWAREVERSION=2021.05.24.1
+      - FIRMWAREVERSION=2021.05.24.1
     image: "nebraltd/hm-config:60e384f5a2c99f200c149014de42086547578db8"
     privileged: true
     network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:3db6baccd78b0ac1f9ad767b3043c59c90055148"
     environment:
-      - 'FIRMWAREVERSION=2021.05.24.1'
+      - 'FIRMWARE_VERSION=2021.05.24.2'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,23 +3,23 @@ version: '2'
 services:
 
   gateway-config:
-  image: "nebraltd/hm-config:3db6baccd78b0ac1f9ad767b3043c59c90055148"
-  environment:
-    - 'FIRMWAREVERSION=2021.05.24.1'
-    - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
-  privileged: true
-  network_mode: "host"
-  cap_add:
-    - NET_ADMIN
-  volumes:
-    - 'miner-storage:/var/data'
-  labels:
-    io.balena.features.dbus: '1'
-    io.balena.features.sysfs: '1'
-    io.balena.features.kernel-modules: '1'
-    io.balena.features.supervisor-api: '1'
-  stop_signal: SIGINT
-  
+    image: "nebraltd/hm-config:3db6baccd78b0ac1f9ad767b3043c59c90055148"
+    environment:
+      - 'FIRMWAREVERSION=2021.05.24.1'
+      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
+    privileged: true
+    network_mode: "host"
+    cap_add:
+      - NET_ADMIN
+    volumes:
+      - 'miner-storage:/var/data'
+    labels:
+      io.balena.features.dbus: '1'
+      io.balena.features.sysfs: '1'
+      io.balena.features.kernel-modules: '1'
+      io.balena.features.supervisor-api: '1'
+    stop_signal: SIGINT
+
   packet-forwarder:
     image: "nebraltd/hm-pktfwd:d8001d3c03b11e9944f71e6e748026d57476590d"
     privileged: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:d2766cb5fc9f8300b8410f1396a252e0f578c694"
+    image: "nebraltd/hm-miner:81be1271a6a95be90428433cfd6194a1eb88dca5"
     ports:
       - "44158:44158/tcp"
       - "1680:1680/udp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   gateway-config:
-    image: "nebraltd/hm-config:1b4f51c0381bdcb87e9c43cf78af8e971315e006"
+    image: "nebraltd/hm-config:0b0e6cbe7242e1b1dfae15a76d8c79839ad8b4b2"
     privileged: true
     network_mode: "host"
     cap_add:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,10 @@
 version: '2'
 
 services:
-  
+
   gateway-config:
     environment:
-    - FIRMWARE=1
+    - FIRMWAREVERSION=2021.05.24.1
     image: "nebraltd/hm-config:0b0e6cbe7242e1b1dfae15a76d8c79839ad8b4b2"
     privileged: true
     network_mode: "host"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     environment:
     - FIRMWAREVERSION=2021.05.24.1
-    image: "nebraltd/hm-config:0b0e6cbe7242e1b1dfae15a76d8c79839ad8b4b2"
+    image: "nebraltd/hm-config:60e384f5a2c99f200c149014de42086547578db8"
     privileged: true
     network_mode: "host"
     cap_add:


### PR DESCRIPTION
This software update will do the following:

- Updates the helium miner to the latest version.
- Fixes an issue where diagnostics app was not showing the correct IP address
- Fixes an issue with the Diagnostics web page not formatting correctly on mobile.
- Adds in improved way to show new firmware versions by passing argument from config.