### PR TITLE
Software Update 2021.06.03.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:6f36477da8fcd9ab6e7d1f97a73c315829278a03"
+    image: "nebraltd/hm-diag:e9f275d2036bf781bab24ba56c22427b5ca8e133"
     environment:
       - 'FIRMWARE_VERSION=2021.06.03.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:83ca1eb787790c715dd4ef1d2a9a55b050b25851"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.01.1'
+      - 'FIRMWARE_VERSION=2021.06.03.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
@@ -47,9 +47,9 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:a024624812c48662d48c997c084acc0acaa79d88"
+    image: "nebraltd/hm-diag:6f36477da8fcd9ab6e7d1f97a73c315829278a03"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.01.1'
+      - 'FIRMWARE_VERSION=2021.06.03.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'


### PR DESCRIPTION
Just a minor software update that resolves the following:

- Diagnostics runs now every minute instead of every 5, making information more up to date.
- Tweaked time on diagnostics to show timezone (UTC)
- Tweaked diagnostics date to be more regionally friendly
- Attempt to show if the miner is relayed (if programmed in correctly)
- Tweaks some logic to fix div by 0 error
- Bumps NGINX version