### PR TITLE
Software Update 2021.06.09.4

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:74c27a4b73f00867a4a65602d694d25dfee2f475"
+    image: "nebraltd/hm-miner:d167140825e4def21aab1e797d84e749b7715bae"
     ports:
       - "44158:44158/tcp"
       - "1680:1680/udp"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     stop_signal: SIGINT
 
   packet-forwarder:
-    image: "nebraltd/hm-pktfwd:6cc4ae91cc2224ff6d06c45b29722c94808ba70a"
+    image: "nebraltd/hm-pktfwd:53ec9ad62e80aa596e1ade87a7f8395ae5130ec3"
     privileged: true
     volumes:
       - 'pktfwdr:/var/pktfwd'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,6 +48,7 @@ services:
 
   diagnostics:
     image: "nebraltd/hm-diag:9338fb4586fef8bc29443bc63ef8f71b20b837eb"
+    privilged: true
     environment:
       - 'FIRMWARE_VERSION=2021.06.09.4'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
@@ -63,8 +64,10 @@ services:
     devices:
       - "/dev/i2c-1:/dev/i2c-1"
     labels:
-      io.balena.features.sysfs: '1'
       io.balena.features.dbus: '1'
+      io.balena.features.sysfs: '1'
+      io.balena.features.kernel-modules: '1'
+      io.balena.features.supervisor-api: '1'
 
   gwmfr:
     image: "nebraltd/hm-gwmfr:68329fce90fa6ba5169c700d763fe941b7e414f4"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:83ca1eb787790c715dd4ef1d2a9a55b050b25851"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.09.3'
+      - 'FIRMWARE_VERSION=2021.06.09.4'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
@@ -47,17 +47,19 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:3c7314c248cdb4632e34e9156e7b02ecb351dc8b"
+    image: "nebraltd/hm-diag:9338fb4586fef8bc29443bc63ef8f71b20b837eb"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.09.3'
+      - 'FIRMWARE_VERSION=2021.06.09.4'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'
+    network_mode: "host"
     ports:
       - '80:80'
     cap_add:
       - SYS_RAWIO
+      - NET_ADMIN
     devices:
       - "/dev/i2c-1:/dev/i2c-1"
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:83ca1eb787790c715dd4ef1d2a9a55b050b25851"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.09.2'
+      - 'FIRMWARE_VERSION=2021.06.09.3'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
@@ -47,9 +47,9 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:949faf735930bfcfb93fcde4d1256563acd1a334"
+    image: "nebraltd/hm-diag:3c7314c248cdb4632e34e9156e7b02ecb351dc8b"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.09.2'
+      - 'FIRMWARE_VERSION=2021.06.09.3'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,7 +47,7 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:90e6b26baf4ffdc3a6484aaf4e23b2a4d5aea78b"
+    image: "nebraltd/hm-diag:7e9e2bbbdd81b5ca7bd22f636ccc672b28cd39ac"
     environment:
       - 'FIRMWARE_VERSION=2021.06.09.4'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,27 +47,22 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:9338fb4586fef8bc29443bc63ef8f71b20b837eb"
-    privileged: true
+    image: "nebraltd/hm-diag:90e6b26baf4ffdc3a6484aaf4e23b2a4d5aea78b"
     environment:
       - 'FIRMWARE_VERSION=2021.06.09.4'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'
-    network_mode: "host"
     ports:
       - '80:80'
     cap_add:
       - SYS_RAWIO
-      - NET_ADMIN
     devices:
       - "/dev/i2c-1:/dev/i2c-1"
     labels:
-      io.balena.features.dbus: '1'
       io.balena.features.sysfs: '1'
-      io.balena.features.kernel-modules: '1'
-      io.balena.features.supervisor-api: '1'
+      io.balena.features.dbus: '1'
 
   gwmfr:
     image: "nebraltd/hm-gwmfr:68329fce90fa6ba5169c700d763fe941b7e414f4"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:83ca1eb787790c715dd4ef1d2a9a55b050b25851"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.09.1'
+      - 'FIRMWARE_VERSION=2021.06.09.2'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
@@ -47,9 +47,9 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:f0b3082c9fbbb752bf492df9a48805f03f7c3159"
+    image: "nebraltd/hm-diag:949faf735930bfcfb93fcde4d1256563acd1a334"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.09.1'
+      - 'FIRMWARE_VERSION=2021.06.09.2'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:83ca1eb787790c715dd4ef1d2a9a55b050b25851"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.03.0'
+      - 'FIRMWARE_VERSION=2021.06.09.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
@@ -49,7 +49,7 @@ services:
   diagnostics:
     image: "nebraltd/hm-diag:e9f275d2036bf781bab24ba56c22427b5ca8e133"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.03.0'
+      - 'FIRMWARE_VERSION=2021.06.09.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
 
   diagnostics:
     image: "nebraltd/hm-diag:9338fb4586fef8bc29443bc63ef8f71b20b837eb"
-    privilged: true
+    privileged: true
     environment:
       - 'FIRMWARE_VERSION=2021.06.09.4'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:83ca1eb787790c715dd4ef1d2a9a55b050b25851"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.09.0'
+      - 'FIRMWARE_VERSION=2021.06.09.1'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
@@ -47,9 +47,9 @@ services:
       # io.balena.features.kernel-modules: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:e9f275d2036bf781bab24ba56c22427b5ca8e133"
+    image: "nebraltd/hm-diag:f0b3082c9fbbb752bf492df9a48805f03f7c3159"
     environment:
-      - 'FIRMWARE_VERSION=2021.06.09.0'
+      - 'FIRMWARE_VERSION=2021.06.09.1'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'


### PR DESCRIPTION
A few changes in this software update:

- Diagnostics now displays more user friendly information when values aren't available
- Diagnostics now colour codes weather it is relayed or not
- Temporarily disable error reporting on diagnostics software to stop issues with sentry
- Bumps helium miner to latest GA.
- Tweaks RSSI value to try and improve witnesssing on 868 Mhz units (EU868, IN865, RU864)