### PR TITLE
Software Update 2021.07.09.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,7 +41,7 @@ services:
       - "/dev/i2c-1:/dev/i2c-1"
     environment:
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
-      - 'RELEASE_BUMPER=foobar'
+      - 'RELEASE_BUMPER=2'
     labels:
       io.balena.features.dbus: '1'
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,8 +28,6 @@ services:
 
   helium-miner:
     image: "nebraltd/hm-miner:7a90b0a07251bd3f5f31e8fb6e7a60cb48cf6212"
-    environment:
-      - 'RELEASE_BUMPER=foobar'
     ports:
       - "44158:44158/tcp"
       - "1680:1680/udp"
@@ -43,6 +41,7 @@ services:
       - "/dev/i2c-1:/dev/i2c-1"
     environment:
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
+      - 'RELEASE_BUMPER=foobar'
     labels:
       io.balena.features.dbus: '1'
 


### PR DESCRIPTION
- Bump hm-miner to fix public key variable issue in diagnostics
- Bump miner to latest GA 070920212