### PR TITLE
feat(rockpi): config, miner, and diag working

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gateway-config:
-    image: "nebraltd/hm-config:38555834fd3b9c632f61592ccfaf7325c37cf4ce"
+    image: "nebraltd/hm-config:5de3322bcb587809b2e091b04bafa79456498130"
     environment:
       - 'FIRMWARE_VERSION=2021.08.31.2'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:6cfa355d27063840ce26f0d8257e03a52e303f8e"
+    image: "nebraltd/hm-miner:94aeacee46b1236b275c80e7da13b2c55596f5bc"
     expose:
       - "4467"
       - "1680"
@@ -37,8 +37,9 @@ services:
       - 'miner-storage:/var/data'
       - 'miner-log:/var/log/miner'
       - 'pktfwdr:/var/pktfwd'
+    privileged: true
     cap_add:
-      - SYS_RAWIO
+      - SYS_RAWIO # https://www.balena.io/docs/learn/develop/hardware/
     devices:
       - "/dev/i2c-1:/dev/i2c-1"
     environment:
@@ -47,7 +48,7 @@ services:
       io.balena.features.dbus: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:ca8f2fcea586242bdc151b1e517b0e2ecff23c3d"
+    image: "nebraltd/hm-diag:fc56f06aaf581f0e76a72191f5943f4baf3b9e6c"
     environment:
       - 'FIRMWARE_VERSION=2021.08.31.2'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
@@ -56,8 +57,9 @@ services:
       - 'miner-storage:/var/data'
     ports:
       - '80:5000'
+    privileged: true
     cap_add:
-      - SYS_RAWIO
+      - SYS_RAWIO # https://www.balena.io/docs/learn/develop/hardware/
     devices:
       - "/dev/i2c-1:/dev/i2c-1"
     labels:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,10 +21,16 @@ services:
     stop_signal: SIGINT
 
   packet-forwarder:
-    image: "nebraltd/hm-pktfwd:677b9956547d028167905699ec6a2c2270129702"
+    image: "67feb315ab530ed62b9d8236a118e4df5d1cd9c0eff5b1faeb82257ffbaa8597"
+    environment:
+      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'  
     privileged: true
     volumes:
       - 'pktfwdr:/var/pktfwd'
+    labels:
+      io.balena.features.dbus: '1'
+    cap_add:
+      - SYS_RAWIO
 
   helium-miner:
     image: "nebraltd/hm-miner:94aeacee46b1236b275c80e7da13b2c55596f5bc"
@@ -45,7 +51,8 @@ services:
     environment:
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     labels:
-      io.balena.features.dbus: '1'
+        io.balena.features.sysfs: '1'
+        io.balena.features.dbus: '1'
 
   diagnostics:
     image: "nebraltd/hm-diag:fc56f06aaf581f0e76a72191f5943f4baf3b9e6c"


### PR DESCRIPTION
**Usage**
To test, you'll need to set ROCKPI_MINER_CONFIG_URL=https://raw.githubusercontent.com/NebraLtd/hm-miner/marvinmarnold/rockpi/rockpi-sys.config on Balena for the helium-miner-service and IS_GPIO_ENABLED=False for gateway-config

If you are not testing with a `Nebra HNT` Balena device, you will also need to copy the correct dbus config onto the host. The files should be copied onto the HOST not the service. Do this manually by copying three example files from [hm-dbus](https://github.com/NebraLtd/hm-dbus) to the below locations. First you will need to enable write permissions with `mount -o remount,rw /`.

- /usr/share/dbus-1/system.d/system-local.conf
- /usr/share/dbus-1/system.d/com.helium.Miner.conf
- /usr/share/dbus-1/system.d/bluetooth.conf

**Why**
We want to support RockPi4 so that we can grow faster and not be dependent on Raspberry Pi.

**How**
Config now has a flag to disable GPIO because RGPIO
and gpiozero currently only support raspberry pi.

Diag can run gateway_mfr successfully with:
`./gateway-mfr-rs/target/aarch64-unknown-linux-musl/release/gateway_mfr --path /dev/i2c-7 test`

Miner uses a special config that points to i2c-7.

**References**
- Diagnostics: https://github.com/NebraLtd/hm-diag/tree/marvinmarnold/rockpi
- Config: https://github.com/NebraLtd/hm-config/tree/marvinmarnold/rockpi
- Miner: https://github.com/NebraLtd/hm-miner/tree/marvinmarnold/rockpi
- Checklist: https://docs.google.com/spreadsheets/d/11R_GrENUib-zyIHUmWbvHKErNOZ05wb0MkbCFYpGp0k/edit#gid=0
- Closes: https://github.com/NebraLtd/hm-config/issues/82