### PR TITLE
Bump miner to 2021_09.26.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:d31a5296a3924eae6dd4186385bfd446388f4975"
+    image: "nebraltd/hm-miner:632813999275f414997ee38c7001f0940abc7d55"
     expose:
       - "4467"
       - "1680"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:805f84ef025883d25b129229d7367c6f6c350722"
     environment:
-      - 'FIRMWARE_VERSION=2021.09.16.1'
+      - 'FIRMWARE_VERSION=2021.09.26.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
@@ -50,7 +50,7 @@ services:
   diagnostics:
     image: "nebraltd/hm-diag:27d108d122a98ea10a86d07b9e18dc0961060f6d"
     environment:
-      - 'FIRMWARE_VERSION=2021.09.16.1'
+      - 'FIRMWARE_VERSION=2021.09.26.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:0c2204b7cb0738944c765d1b20b599d767587c5d"
+    image: "nebraltd/hm-miner:d783da7e514789c47c349506a3437a405a8d6ab2"
     expose:
       - "4467"
       - "1680"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:d783da7e514789c47c349506a3437a405a8d6ab2"
+    image: "nebraltd/hm-miner:d31a5296a3924eae6dd4186385bfd446388f4975"
     expose:
       - "4467"
       - "1680"


### PR DESCRIPTION
Helium have changed the GA format again to 2021_09.26.0 instead of what it was typically before 2021.09.26.0 so hopefully this doesn't break anything with regards to the sys.config location (need to test thoroughly)

**Why**
<!-- What is the objective of this work? -->

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->