### PR TITLE
fix: gwmfr uses correct touch method

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,7 @@ services:
       io.balena.features.dbus: '1'
 
   gwmfr:
-    image: "nebraltd/hm-gwmfr:0fce952a44342ad8af061c04e20d3b39014c04b9"
+    image: "nebraltd/hm-gwmfr:3a8196239d939fc6d0383a4f39b4fb475c62bad5"
     cap_add:
       - SYS_RAWIO
     devices:


### PR DESCRIPTION
Why
Was getting an error when trying to touch a file with pathlib, ModuleNotFoundError: No module named 'pathlib'. Because pathlib is not included in python3-minimal.

How
Use open().

References
Fixes: #18
New method: https://stackoverflow.com/questions/12654772/create-empty-file-using-python/12654798
Old method: https://stackoverflow.com/questions/1158076/implement-touch-using-python
gwmfr: https://github.com/NebraLtd/hm-gwmfr/pull/19