### PR TITLE
Bump to 2021.10.07.0_GA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     stop_signal: SIGINT
 
   packet-forwarder:
-    image: "nebraltd/hm-pktfwd:5a0178341e69ecbf6b1dbc8463f6bd1231e9e657"
+    image: "nebraltd/hm-pktfwd:a48637d62ea66ab10e3738bf883745b2260fd774"
     privileged: true
     volumes:
       - 'pktfwdr:/var/pktfwd'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - 'FIRMWARE_VERSION=2021.09.27.3'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
-      - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/session_bus_socket'
+      - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
     cap_add:
@@ -18,7 +18,6 @@ services:
       io.balena.features.dbus: '1'
       io.balena.features.sysfs: '1'
       io.balena.features.kernel-modules: '1'
-      io.balena.features.supervisor-api: '1'
     stop_signal: SIGINT
 
   packet-forwarder:
@@ -43,16 +42,15 @@ services:
     devices:
       - "/dev/i2c-1:/dev/i2c-1"
     environment:
-      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/session_bus_socket'
+      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
       - 'RELEASE_BUMPER=snapshotbumper'
     labels:
       io.balena.features.dbus: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:bf959aca6264d526163797bb9532469fbf276a65"
+    image: "nebraltd/hm-diag:14a5cf868910c56c465fb9eebd41941ca199106f"
     environment:
       - 'FIRMWARE_VERSION=2021.09.27.3'
-      - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/sesion_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'
@@ -64,7 +62,6 @@ services:
       - "/dev/i2c-1:/dev/i2c-1"
     labels:
       io.balena.features.sysfs: '1'
-      io.balena.features.dbus: '1'
 
   gwmfr:
     image: "nebraltd/hm-gwmfr:3a8196239d939fc6d0383a4f39b4fb475c62bad5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gateway-config:
-    image: "nebraltd/hm-config:805f84ef025883d25b129229d7367c6f6c350722"
+    image: "nebraltd/hm-config:f722f1243db45f29d4d589184d61880b98938a82"
     environment:
       - 'FIRMWARE_VERSION=2021.09.27.3'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:70dbc27b98c233e969001f8e3bb91371a3ef7bdb"
+    image: "nebraltd/hm-miner:98107f50257de420a42dec50cca6e2f667f899ad"
     expose:
       - "4467"
       - "1680"
@@ -48,7 +48,7 @@ services:
       io.balena.features.dbus: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:4fa635fc322185d181841f038226dbe9026b44a8"
+    image: "nebraltd/hm-diag:bf959aca6264d526163797bb9532469fbf276a65"
     environment:
       - 'FIRMWARE_VERSION=2021.09.27.3'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:98107f50257de420a42dec50cca6e2f667f899ad"
+    image: "nebraltd/hm-miner:a4d8781845b5d9ea262e705e5d44533e5bdfec88"
     expose:
       - "4467"
       - "1680"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
     environment:
       - 'FIRMWARE_VERSION=2021.09.27.3'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
+      - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/session_bus_socket'
     privileged: true
     network_mode: "host"
     cap_add:
@@ -42,7 +43,7 @@ services:
     devices:
       - "/dev/i2c-1:/dev/i2c-1"
     environment:
-      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
+      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/session_bus_socket'
       - 'RELEASE_BUMPER=snapshotbumper'
     labels:
       io.balena.features.dbus: '1'
@@ -51,7 +52,7 @@ services:
     image: "nebraltd/hm-diag:bf959aca6264d526163797bb9532469fbf276a65"
     environment:
       - 'FIRMWARE_VERSION=2021.09.27.3'
-      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
+      - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/sesion_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:f722f1243db45f29d4d589184d61880b98938a82"
     environment:
-      - 'FIRMWARE_VERSION=2021.09.27.3'
+      - 'FIRMWARE_VERSION=2021.10.07.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
       - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:a4d8781845b5d9ea262e705e5d44533e5bdfec88"
+    image: "nebraltd/hm-miner:67ffe80b102cf14ea0fa4a17a66b71affb5c4d96"
     expose:
       - "4467"
       - "1680"
@@ -50,7 +50,7 @@ services:
   diagnostics:
     image: "nebraltd/hm-diag:14a5cf868910c56c465fb9eebd41941ca199106f"
     environment:
-      - 'FIRMWARE_VERSION=2021.09.27.3'
+      - 'FIRMWARE_VERSION=2021.10.07.0'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Bump to latest miner (and update other containers at the same time)

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Bump containers

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://github.com/NebraLtd/hm-miner/commit/6a9cd79510b53a4e7e77dd1b4f90fc233e69d24c
https://engineering.helium.com/2021/10/08/blockchain-release-block-gossip-state-channels-and-poc-v11-fixes.html