### PR TITLE
change to dbus container and pull in fixes

### DIFF
--- a/.github/workflows/push-to-prod.yml
+++ b/.github/workflows/push-to-prod.yml
@@ -78,3 +78,27 @@ jobs:
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
           balena_command: "deploy nebraltd/helium-indoor-470 --logs"
+
+  open-fleet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Balena Deploy
+        uses: nebraltd/balena-cli-action@v12.48.12
+        if: success()
+        with:
+          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
+          balena_command: "deploy nebraltd/helium-miner --logs"
+
+  commercial:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Balena Deploy
+        uses: nebraltd/balena-cli-action@v12.48.12
+        if: success()
+        with:
+          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
+          balena_command: "deploy nebraltd/helium-miner-commercial --logs"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
-    network_mode: "host"
+    network_mode: host
     cap_add:
       - NET_ADMIN
     volumes:
@@ -30,7 +30,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:6a9cd79510b53a4e7e77dd1b4f90fc233e69d24c
+    image: nebraltd/hm-miner:feca3437d87793336fe97a33779db6f5a52ab3a8
     depends_on:
       - dbus-session
     expose:
@@ -46,15 +46,13 @@ services:
     cap_add:
       - SYS_RAWIO
     devices:
-      - "/dev/i2c-1:/dev/i2c-1"
+      - /dev/i2c-1:/dev/i2c-1
     environment:
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
       - RELEASE_BUMPER=foobar
 
   diagnostics:
     image: nebraltd/hm-diag:a2176a8d0ca45cac60ab491d8a5020cb6b76e4f7
-    depends_on:
-      - dbus-session
     environment:
       - FIRMWARE_VERSION=2021.10.07.0
     volumes:
@@ -65,7 +63,7 @@ services:
     cap_add:
       - SYS_RAWIO
     devices:
-      - "/dev/i2c-1:/dev/i2c-1"
+      - /dev/i2c-1:/dev/i2c-1
     labels:
       io.balena.features.sysfs: '1'
 
@@ -74,14 +72,14 @@ services:
     cap_add:
       - SYS_RAWIO
     devices:
-      - "/dev/i2c-1:/dev/i2c-1"
+      - /dev/i2c-1:/dev/i2c-1
     restart: on-failure
     volumes:
-      - 'miner-storage:/var/data'
+      - miner-storage:/var/data
 
   upnp:
     image: nebraltd/hm-upnp:56722295754eddc65496c3f08f0cb35e76ad0586
-    network_mode: "host"
+    network_mode: host
     restart: on-failure
     volumes:
       - pktfwdr:/var/pktfwd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     depends_on:
       - dbus-session
     environment:
-      - FIRMWARE_VERSION=2021.10.07.0
+      - FIRMWARE_VERSION=2021.10.07.1
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -54,7 +54,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:a2176a8d0ca45cac60ab491d8a5020cb6b76e4f7
     environment:
-      - FIRMWARE_VERSION=2021.10.07.0
+      - FIRMWARE_VERSION=2021.10.07.1
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     environment:
       - 'FIRMWARE_VERSION=2021.09.27.3'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
-      - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/session_bus_socket'
+      - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
     network_mode: "host"
     cap_add:
@@ -18,7 +18,6 @@ services:
       io.balena.features.dbus: '1'
       io.balena.features.sysfs: '1'
       io.balena.features.kernel-modules: '1'
-      io.balena.features.supervisor-api: '1'
     stop_signal: SIGINT
 
   packet-forwarder:
@@ -43,16 +42,15 @@ services:
     devices:
       - "/dev/i2c-1:/dev/i2c-1"
     environment:
-      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/session_bus_socket'
+      - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
       - 'RELEASE_BUMPER=snapshotbumper'
     labels:
       io.balena.features.dbus: '1'
 
   diagnostics:
-    image: "nebraltd/hm-diag:bf959aca6264d526163797bb9532469fbf276a65"
+    image: "nebraltd/hm-diag:14a5cf868910c56c465fb9eebd41941ca199106f"
     environment:
       - 'FIRMWARE_VERSION=2021.09.27.3'
-      - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/sesion_bus_socket'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'
@@ -64,7 +62,6 @@ services:
       - "/dev/i2c-1:/dev/i2c-1"
     labels:
       io.balena.features.sysfs: '1'
-      io.balena.features.dbus: '1'
 
   gwmfr:
     image: "nebraltd/hm-gwmfr:3a8196239d939fc6d0383a4f39b4fb475c62bad5"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gateway-config:
-    image: nebraltd/hm-config:bf65844ad2879f089ce747282cb87a1b4b33e8b5
+    image: nebraltd/hm-config:711fbbd4b3c694d57263b63db52f2ebb580b40a4
     depends_on:
       - dbus-session
     environment:
@@ -52,7 +52,7 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:a2176a8d0ca45cac60ab491d8a5020cb6b76e4f7
+    image: nebraltd/hm-diag:8770a234f2b188074ae36ed8eb6da1536246b816
     environment:
       - FIRMWARE_VERSION=2021.10.07.1
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,9 +18,9 @@ services:
       - miner-storage:/var/data
       - dbus:/session/dbus
     labels:
-      io.balena.features.sysfs: '1'
-      io.balena.features.kernel-modules: '1'
-      io.balena.features.dbus: '1'
+      io.balena.features.sysfs: 1
+      io.balena.features.kernel-modules: 1
+      io.balena.features.dbus: 1
     stop_signal: SIGINT
 
   packet-forwarder:
@@ -65,7 +65,7 @@ services:
     devices:
       - /dev/i2c-1:/dev/i2c-1
     labels:
-      io.balena.features.sysfs: '1'
+      io.balena.features.sysfs: 1
 
   gwmfr:
     image: nebraltd/hm-gwmfr:e90de0b302772818780e61b20499f95e6191a3ff

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   gateway-config:
     image: "nebraltd/hm-config:f722f1243db45f29d4d589184d61880b98938a82"
     environment:
-      - 'FIRMWARE_VERSION=2021.09.27.3'
+      - 'FIRMWARE_VERSION=2021.10.07.0'
       - 'DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
       - 'DBUS_SESSION_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket'
     privileged: true
@@ -27,7 +27,7 @@ services:
       - 'pktfwdr:/var/pktfwd'
 
   helium-miner:
-    image: "nebraltd/hm-miner:a4d8781845b5d9ea262e705e5d44533e5bdfec88"
+    image: "nebraltd/hm-miner:67ffe80b102cf14ea0fa4a17a66b71affb5c4d96"
     expose:
       - "4467"
       - "1680"
@@ -50,7 +50,7 @@ services:
   diagnostics:
     image: "nebraltd/hm-diag:14a5cf868910c56c465fb9eebd41941ca199106f"
     environment:
-      - 'FIRMWARE_VERSION=2021.09.27.3'
+      - 'FIRMWARE_VERSION=2021.10.07.0'
     volumes:
       - 'pktfwdr:/var/pktfwd'
       - 'miner-storage:/var/data'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,7 +30,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:feca3437d87793336fe97a33779db6f5a52ab3a8
+    image: nebraltd/hm-miner:77f954817be7c2e5ce3de7383134fd7417fc507b
     depends_on:
       - dbus-session
     expose:


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

- enable usage of devices without com.helium.Miner.conf file (e.g. rockpi)
- change to dbus container setup
- pull in fixes to miner/diag/config containers to suit the above
- fix formatting of docker-compose.yml
- add new consolidation balena fleets to deploy workflow

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Bump containers and update workflow

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Closes: #105 