### PR TITLE
fix: add depends on for packet forwarder

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,8 @@ services:
 
   packet-forwarder:
     image: nebraltd/hm-pktfwd:a901153
+    depends_on:
+      - helium-miner
     restart: always
     privileged: true
     volumes:


### PR DESCRIPTION
The packet forwarder actually requires the miner container to be able to accept connections on the hostname helium-miner before it will be able to start the concentrator.

This adds a depends_on to not attempt to start the packet forwarder container until the miner container is up

**Why**
<!-- What is the objective of this work? -->

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->