### PR TITLE
Added documentation to the readme for quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,33 @@ The `docker-compose.yml` file is pushed to [Balena](https://www.balena.io/) (usi
 
 There are currently six different services running within this device, which are all outlined below.
 
+##  Quick Start
+
+This is a guide to help you get started with the repository and get it running on your local device. This guide is focused on pushing the repository onto a Raspberry Pi using Balena.
+
+**Prerequisites:**
+- Local Test Device (Ex: Raspberry Pi)
+- Computer for development and pushing to the device
+- Git installed  [download](https://git-scm.com/downloads)
+- Balena CLI (Install located on Balena step in quick start steps below)
+
+**Quick Start Steps:**
+
+Step 1: Clone the repository to your local machine using one of the following commands:
+HTTP: ```git clone https://github.com/NebraLtd/helium-miner-software.git```
+SSH: ```git clone git@github.com:NebraLtd/helium-miner-software.git```
+
+Step 2: Follow the get started guide for Balena to help you install Balena on your local test device and get a fleet setup so you can start pushing code to it. [here](https://www.balena.io/docs/learn/getting-started/raspberrypi3/nodejs/)
+
+Step 3: Once you've gone through the steps and have Balena setup with your device in your fleet. Open your cli terminal and navigate to the root directory of the cloned repository. (Ex: /usr/name/documents/helium-miner-software)
+
+Step 4: Once you're at the root directory. You want to push the code by running the following command:
+```bash
+$ balena push <fleet-name>
+```
+
+Step 5. Once complete check your fleet on the Balena dashboard and all modules should be running on the local test device.
+
 ## Diagnostics
 
 Repo: [github.com/NebraLtd/hm-diag](https://github.com/NebraLtd/hm-diag)


### PR DESCRIPTION
Why
While going through the document I felt like the steps provided helped me a lot with getting my raspberry pi setup with Balena and pushing code using the fleet system. I thought it would make a great addition to the documentation.

How
I included a little quick start guide with information on prerequisites and steps to help guide you through the process from start to finish of setting up your raspberry pi as a development environment for the repository and the modules included with it. I also included the useful Balena quick start guide with the step-by-step process of getting your first fleet up and running using the raspberry pi.