### PR TITLE
feat: bump GA to 2021.11.04.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.02.0
+      - FIRMWARE_VERSION=2021.11.04.2
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -32,7 +32,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:20ef80b
+    image: nebraltd/hm-miner:e348a6f
     depends_on:
       - dbus-session
       - diagnostics
@@ -58,7 +58,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:d9ab173
     environment:
-      - FIRMWARE_VERSION=2021.11.02.0
+      - FIRMWARE_VERSION=2021.11.04.2
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data


### PR DESCRIPTION
Draft until #195 has been vetted in testnet for 24h. Deployed at 3pm US Central on Nov 8, 2021.

**Why**
Master branch is not stable so applying GA directly.

**How**
Cherry-pick from: https://github.com/NebraLtd/helium-miner-software/pull/195
