### PR TITLE
release(testnet): GA 2021.11.10.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.04.2
+      - FIRMWARE_VERSION=2021.11.10.0
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -34,7 +34,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:e348a6f
+    image: nebraltd/hm-miner:6ee720d
     depends_on:
       - dbus-session
       - diagnostics
@@ -60,7 +60,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:d444f93
     environment:
-      - FIRMWARE_VERSION=2021.11.04.2
+      - FIRMWARE_VERSION=2021.11.10.0
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data


### PR DESCRIPTION
**Why**
Keep up with GA releases.

**How**
Uses [new hm-miner by Mr. Bump](https://github.com/NebraLtd/hm-miner/commit/6ee720d968173f50c92a67f538bc69837dd61b9f).

**References**
Related to: https://github.com/NebraLtd/helium-miner-software/issues/203