### PR TITLE
release(prod): GA 2021.11.10.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.02.0
+      - FIRMWARE_VERSION=2021.11.10.0
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -32,7 +32,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:20ef80b
+    image: nebraltd/hm-miner:6ee720d
     depends_on:
       - dbus-session
       - diagnostics
@@ -58,7 +58,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:d9ab173
     environment:
-      - FIRMWARE_VERSION=2021.11.02.0
+      - FIRMWARE_VERSION=2021.11.10.0
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data


### PR DESCRIPTION
Draft until #205 has been vetted in testnet for 24h. Released at 9:30am (15:30 UTC) 11/11/21.

**Why**
Master branch is not stable so applying GA directly.

**How**
Bump to hm-miner to commit https://github.com/NebraLtd/hm-miner/commit/6ee720d968173f50c92a67f538bc69837dd61b9f and update `FIRMWARE_VERSION`s.

**References**
- Closes: https://github.com/NebraLtd/helium-miner-software/issues/203
- Potentially closes: https://github.com/NebraLtd/helium-miner-software/pull/196