### PR TITLE
fix: ECC locking and initFile

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:d444f93
+    image: nebraltd/hm-diag:12420cf
     environment:
       - FIRMWARE_VERSION=2021.11.10.0
     volumes:


### PR DESCRIPTION
Going to do some testing before converting from draft.

**Why**
Manufacturing has slowed for a number of reasons. This PR addresses ECC locking and the initFile intentionally throwing 500s. 

**How**
Lock ECC usage and ensure initFile always returns something.

**References**
- Closes: https://github.com/NebraLtd/hm-diag/issues/167
- Includes: https://github.com/NebraLtd/hm-diag/issues/198
- Includes: https://github.com/NebraLtd/hm-pyhelper/issues/59
- Includes: https://github.com/NebraLtd/hm-diag/issues/181

Additional work still needed:
- https://github.com/NebraLtd/hm-diag/issues/204
- https://github.com/NebraLtd/Hotspot-Production-Tool/issues/32
- https://github.com/NebraLtd/Hotspot-Production-Tool/issues/33