### PR TITLE
release(prod): 2021.11.11.0-1, ECC concurrency, initFile robustness, and pktfwd rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,33 +6,6 @@ The `docker-compose.yml` file is pushed to [Balena](https://www.balena.io/) (usi
 
 There are currently six different services running within this device, which are all outlined below.
 
-##  Quick Start
-
-This is a guide to help you get started with the repository and get it running on your local device. This guide is focused on pushing the repository onto a Raspberry Pi using Balena.
-
-**Prerequisites:**
-- Local Test Device (Ex: Raspberry Pi)
-- Computer for development and pushing to the device
-- Git installed  [download](https://git-scm.com/downloads)
-- Balena CLI (Install located on Balena step in quick start steps below)
-
-**Quick Start Steps:**
-
-Step 1: Clone the repository to your local machine using one of the following commands:
-HTTP: ```git clone https://github.com/NebraLtd/helium-miner-software.git```
-SSH: ```git clone git@github.com:NebraLtd/helium-miner-software.git```
-
-Step 2: Follow the get started guide for Balena to help you install Balena on your local test device and get a fleet setup so you can start pushing code to it. [here](https://www.balena.io/docs/learn/getting-started/raspberrypi3/nodejs/)
-
-Step 3: Once you've gone through the steps and have Balena setup with your device in your fleet. Open your cli terminal and navigate to the root directory of the cloned repository. (Ex: /usr/name/documents/helium-miner-software)
-
-Step 4: Once you're at the root directory. You want to push the code by running the following command:
-```bash
-$ balena push <fleet-name>
-```
-
-Step 5. Once complete check your fleet on the Balena dashboard and all modules should be running on the local test device.
-
 ## Diagnostics
 
 Repo: [github.com/NebraLtd/hm-diag](https://github.com/NebraLtd/hm-diag)
@@ -70,6 +43,33 @@ This container attempts to use UPnP to set up a port forwarding rule, if your ro
 Repo: [github.com/balenablocks/dbus](https://github.com/balenablocks/dbus)
 
 This container configures a DBus session bus instance that is used by the gateway config container to communicate with the miner code (note that there is also a separate system bus running on the host OS which is used by gateway config to communicate with bluez for configuring Bluetooth services). This removes the need to have a custom `com.helium.Miner.conf` dbus config file on the host OS as was done previously (and meant we had to run a custom balena device type).
+
+#  Quick Start
+
+This is a guide to help you get started with the repository and get it running on your local device. This guide is focused on pushing the repository onto a Raspberry Pi using Balena.
+
+**Prerequisites:**
+- Local Test Device (Ex: Raspberry Pi)
+- Computer for development and pushing to the device
+- Git installed  [download](https://git-scm.com/downloads)
+- Balena CLI (Install located on Balena step in quick start steps below)
+
+**Quick Start Steps:**
+
+Step 1: Clone the repository to your local machine using one of the following commands:
+HTTP: ```git clone https://github.com/NebraLtd/helium-miner-software.git```
+SSH: ```git clone git@github.com:NebraLtd/helium-miner-software.git```
+
+Step 2: Follow the get started guide for Balena to help you install Balena on your local test device and get a fleet setup so you can start pushing code to it. [here](https://www.balena.io/docs/learn/getting-started/raspberrypi3/nodejs/)
+
+Step 3: Once you've gone through the steps and have Balena setup with your device in your fleet. Open your cli terminal and navigate to the root directory of the cloned repository. (Ex: /usr/name/documents/helium-miner-software)
+
+Step 4: Once you're at the root directory. You want to push the code by running the following command:
+```bash
+$ balena push <fleet-name>
+```
+
+Step 5. Once complete check your fleet on the Balena dashboard and all modules should be running on the local test device.
 
 # Device Configuration / Fleet Configuration Notes
 

--- a/README.md
+++ b/README.md
@@ -51,25 +51,25 @@ This is a guide to help you get started with the repository and get it running o
 **Prerequisites:**
 - Local Test Device (Ex: Raspberry Pi)
 - Computer for development and pushing to the device
-- Git installed  [download](https://git-scm.com/downloads)
-- Balena CLI (Install located on Balena step in quick start steps below)
+- Git installed - [download here](https://git-scm.com/downloads)
+- [Balena CLI](https://github.com/balena-io/balena-cli) (Install located on Balena step in quick start steps below)
 
-**Quick Start Steps:**
+### Quick Start Steps
 
-Step 1: Clone the repository to your local machine using one of the following commands:
-HTTP: ```git clone https://github.com/NebraLtd/helium-miner-software.git```
-SSH: ```git clone git@github.com:NebraLtd/helium-miner-software.git```
+**Step 1:** Clone the repository to your local machine using one of the following commands:
+- HTTP: `git clone https://github.com/NebraLtd/helium-miner-software.git`
+- SSH: `git clone git@github.com:NebraLtd/helium-miner-software.git`
 
-Step 2: Follow the get started guide for Balena to help you install Balena on your local test device and get a fleet setup so you can start pushing code to it. [here](https://www.balena.io/docs/learn/getting-started/raspberrypi3/nodejs/)
+**Step 2:** Follow the [getting started guide](https://www.balena.io/docs/learn/getting-started/raspberrypi3/nodejs/) for Balena to help you install Balena on your local test device and get a fleet setup so you can start pushing code to it.
 
-Step 3: Once you've gone through the steps and have Balena setup with your device in your fleet. Open your cli terminal and navigate to the root directory of the cloned repository. (Ex: /usr/name/documents/helium-miner-software)
+**Step 3:** Once you've gone through the steps and have Balena setup with your device in your fleet, open your cli terminal and navigate to the root directory of the cloned repository (Ex: /usr/name/documents/helium-miner-software).
 
-Step 4: Once you're at the root directory. You want to push the code by running the following command:
+**Step 4:** Once you're at the root directory. You want to push the code by running the following command:
 ```bash
 $ balena push <fleet-name>
 ```
 
-Step 5. Once complete check your fleet on the Balena dashboard and all modules should be running on the local test device.
+**Step 5:** Once complete check your fleet on the Balena dashboard and all modules should be running on the local test device.
 
 # Device Configuration / Fleet Configuration Notes
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,33 @@ The `docker-compose.yml` file is pushed to [Balena](https://www.balena.io/) (usi
 
 There are currently six different services running within this device, which are all outlined below.
 
+##  Quick Start
+
+This is a guide to help you get started with the repository and get it running on your local device. This guide is focused on pushing the repository onto a Raspberry Pi using Balena.
+
+**Prerequisites:**
+- Local Test Device (Ex: Raspberry Pi)
+- Computer for development and pushing to the device
+- Git installed  [download](https://git-scm.com/downloads)
+- Balena CLI (Install located on Balena step in quick start steps below)
+
+**Quick Start Steps:**
+
+Step 1: Clone the repository to your local machine using one of the following commands:
+HTTP: ```git clone https://github.com/NebraLtd/helium-miner-software.git```
+SSH: ```git clone git@github.com:NebraLtd/helium-miner-software.git```
+
+Step 2: Follow the get started guide for Balena to help you install Balena on your local test device and get a fleet setup so you can start pushing code to it. [here](https://www.balena.io/docs/learn/getting-started/raspberrypi3/nodejs/)
+
+Step 3: Once you've gone through the steps and have Balena setup with your device in your fleet. Open your cli terminal and navigate to the root directory of the cloned repository. (Ex: /usr/name/documents/helium-miner-software)
+
+Step 4: Once you're at the root directory. You want to push the code by running the following command:
+```bash
+$ balena push <fleet-name>
+```
+
+Step 5. Once complete check your fleet on the Balena dashboard and all modules should be running on the local test device.
+
 ## Diagnostics
 
 Repo: [github.com/NebraLtd/hm-diag](https://github.com/NebraLtd/hm-diag)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.10.27.0
+      - FIRMWARE_VERSION=2021.10.29.0
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -34,7 +34,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:f223356
+    image: nebraltd/hm-miner:c995074
     depends_on:
       - dbus-session
       - diagnostics
@@ -60,7 +60,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:68ae2fe
     environment:
-      - FIRMWARE_VERSION=2021.10.27.0
+      - FIRMWARE_VERSION=2021.10.29.0
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gateway-config:
-    image: nebraltd/hm-config:3168c36
+    image: nebraltd/hm-config:41f44d3
     depends_on:
       - dbus-session
       - diagnostics
@@ -55,7 +55,7 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:9ba7848
+    image: nebraltd/hm-diag:d9ab173
     environment:
       - FIRMWARE_VERSION=2021.10.18.1
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.10.18.1
+      - FIRMWARE_VERSION=2021.10.27.0
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -34,7 +34,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:8819d54
+    image: nebraltd/hm-miner:f223356
     depends_on:
       - dbus-session
       - diagnostics
@@ -60,7 +60,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:68ae2fe
     environment:
-      - FIRMWARE_VERSION=2021.10.18.1
+      - FIRMWARE_VERSION=2021.10.27.0
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,7 +56,7 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:d9ab173
+    image: nebraltd/hm-diag:889e6f7
     environment:
       - FIRMWARE_VERSION=2021.10.18.1
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.11.0
+      - FIRMWARE_VERSION=2021.11.11.0-1
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -60,7 +60,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:12420cf
     environment:
-      - FIRMWARE_VERSION=2021.11.11.0
+      - FIRMWARE_VERSION=2021.11.11.0-1
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.10.29.0
+      - FIRMWARE_VERSION=2021.11.02.0
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -34,7 +34,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:c995074
+    image: nebraltd/hm-miner:20ef80b
     depends_on:
       - dbus-session
       - diagnostics
@@ -60,7 +60,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:68ae2fe
     environment:
-      - FIRMWARE_VERSION=2021.10.29.0
+      - FIRMWARE_VERSION=2021.11.02.0
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     stop_signal: SIGINT
 
   packet-forwarder:
-    image: nebraltd/hm-pktfwd:1213210
+    image: nebraltd/hm-pktfwd:3f7c41e
     depends_on:
       - helium-miner
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gateway-config:
-    image: nebraltd/hm-config:951749c
+    image: nebraltd/hm-config:e6a4b16
     depends_on:
       - dbus-session
       - diagnostics
@@ -25,7 +25,7 @@ services:
     stop_signal: SIGINT
 
   packet-forwarder:
-    image: nebraltd/hm-pktfwd:a901153
+    image: nebraltd/hm-pktfwd:57f52a5
     depends_on:
       - helium-miner
     restart: always
@@ -58,7 +58,7 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:889e6f7
+    image: nebraltd/hm-diag:68ae2fe
     environment:
       - FIRMWARE_VERSION=2021.10.18.1
     volumes:
@@ -74,7 +74,7 @@ services:
       io.balena.features.sysfs: 1
 
   upnp:
-    image: nebraltd/hm-upnp:9a092ca
+    image: nebraltd/hm-upnp:9c18f02
     network_mode: host
     restart: on-failure
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -72,7 +72,7 @@ services:
       io.balena.features.sysfs: 1
 
   upnp:
-    image: nebraltd/hm-upnp:5672229
+    image: nebraltd/hm-upnp:9a092ca
     network_mode: host
     restart: on-failure
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,12 +3,12 @@ version: '2'
 services:
 
   gateway-config:
-    image: nebraltd/hm-config:e6a4b16
+    image: nebraltd/hm-config:8070d87
     depends_on:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.02.0
+      - FIRMWARE_VERSION=2021.11.02.1
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -58,9 +58,9 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:68ae2fe
+    image: nebraltd/hm-diag:d444f93
     environment:
-      - FIRMWARE_VERSION=2021.11.02.0
+      - FIRMWARE_VERSION=2021.11.02.1
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,8 @@ services:
     stop_signal: SIGINT
 
   packet-forwarder:
-    image: nebraltd/hm-pktfwd:76897fd
+    image: nebraltd/hm-pktfwd:a901153
+    restart: always
     privileged: true
     volumes:
       - pktfwdr:/var/pktfwd

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:d444f93
+    image: nebraltd/hm-diag:12420cf
     environment:
       - FIRMWARE_VERSION=2021.11.11.0
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gateway-config:
-    image: nebraltd/hm-config:41f44d3
+    image: nebraltd/hm-config:951749c
     depends_on:
       - dbus-session
       - diagnostics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -71,16 +71,6 @@ services:
     labels:
       io.balena.features.sysfs: 1
 
-  gwmfr:
-    image: nebraltd/hm-gwmfr:c931113
-    cap_add:
-      - SYS_RAWIO
-    devices:
-      - /dev/i2c-1:/dev/i2c-1
-    restart: on-failure
-    volumes:
-      - miner-storage:/var/data
-
   upnp:
     image: nebraltd/hm-upnp:5672229
     network_mode: host


### PR DESCRIPTION
**Why**
`master` and `production` have diverged. This will put them back in parity. **Warning, because of the drift, this PR requires extra attention before merging.**

**How**
Because the branches have diverged, `master` cannot be directly merged into production. This PR solves merge conflicts. It will need to be merged into `production` and back-merged into `master`. `-1` also appended to `FIRMWARE_VERSION` to indicate that it is distinct Nebra release using the same Helium version.

**References**
- Testnet notes and changelog: https://github.com/NebraLtd/helium-miner-software/pull/209
- Includes: https://github.com/NebraLtd/hm-pktfwd/pull/59