### PR TITLE
Bump diagnostics to handle helium api errors

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,7 +58,7 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:2c92877
+    image: nebraltd/hm-diag:b1210ec
     environment:
       - FIRMWARE_VERSION=2021.11.17.2-1
     volumes:


### PR DESCRIPTION
Fix for issue #223

**Why**
Bump diag container version to fix #223

**How**
Bump diag container to version NebraLtd/hm-diag@b1210ec

**References**

Closes: [#223](https://github.com/NebraLtd/hm-diag/issues/223)