### PR TITLE
feat: add rockpi support to miner

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.17.2-2
+      - FIRMWARE_VERSION=2021.11.17.2-3
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -25,7 +25,7 @@ services:
     stop_signal: SIGINT
 
   packet-forwarder:
-    image: nebraltd/hm-pktfwd:3a55914
+    image: nebraltd/hm-pktfwd:e067bef
     depends_on:
       - helium-miner
     restart: always
@@ -34,7 +34,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:b34655f
+    image: nebraltd/hm-miner:8cec30b
     depends_on:
       - dbus-session
       - diagnostics
@@ -60,7 +60,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:7e26f35
     environment:
-      - FIRMWARE_VERSION=2021.11.17.2-2
+      - FIRMWARE_VERSION=2021.11.17.2-3
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Support rockpi with custom docker.config file to enable i2c bus i2c-7

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Bumps miner container to 8cec30b in order to:

- add RockPi config file override to start-miner.sh
- add docker.config.rockpi template and use as default for rockpi
- update dockerfile to copy new template
- update README
- bump packet forwarder to latest version

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Relates-to: NebraLtd/hm-miner#53
Relates-to: NebraLtd/hm-miner#31
Relates-to: NebraLtd/hm-block-tracker#52
Supersedes: #239