### PR TITLE
feat: rebuild dbus container with touchfile

### DIFF
--- a/dbus/Dockerfile
+++ b/dbus/Dockerfile
@@ -1,0 +1,2 @@
+FROM balenablocks/dbus:rpi-0.0.2
+COPY ./force-restart-touchfile /usr/src/app/force-restart-touchfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -81,7 +81,8 @@ services:
       - pktfwdr:/var/pktfwd
 
   dbus-session:
-    image: balenablocks/dbus:rpi-0.0.2
+    build: dbus/.
+    image: nebra-balenablocks-dbus
     restart: always
     volumes:
       - dbus:/session/dbus


### PR DESCRIPTION
**Why**
In an attempt to force the container to recover, make a trivial change to the container.

**How**
Add a touchfile to the dbus-session container.

**References**
- Related to: https://github.com/NebraLtd/product-management/issues/28 