### PR TITLE
release(prod): bump miner to 2021.11.19.0 GA

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,6 @@ services:
       - SYS_RAWIO
     devices:
       - /dev/i2c-1:/dev/i2c-1
-      - /dev/i2c-7:/dev/i2c-7
     restart: on-failure
     environment:
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
@@ -71,7 +70,6 @@ services:
       - SYS_RAWIO
     devices:
       - /dev/i2c-1:/dev/i2c-1
-      - /dev/i2c-7:/dev/i2c-7
     labels:
       io.balena.features.sysfs: 1
 


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Bump to 2021.11.19.0 GA

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Bump up latest GA in hm-miner
https://github.com/NebraLtd/hm-miner/commit/0d4ce82e61a6d2fcb4a029c9d51b6de8c0443e48

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Ref #246
Closes: #251 

https://engineering.helium.com/2021/11/19/blockchain-release-sync-and-snapshot-improvements.html