### PR TITLE
release(testnet): Update miner to latest GA 2021.11.21.1

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.19.0
+      - FIRMWARE_VERSION=2021.11.21.1
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -34,7 +34,7 @@ services:
       - pktfwdr:/var/pktfwd
 
   helium-miner:
-    image: nebraltd/hm-miner:0d4ce82
+    image: nebraltd/hm-miner:31eeca0
     depends_on:
       - dbus-session
       - diagnostics
@@ -60,7 +60,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:7e26f35
     environment:
-      - FIRMWARE_VERSION=2021.11.19.0
+      - FIRMWARE_VERSION=2021.11.21.1
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data
@@ -87,7 +87,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.11.19.0
+      - FIRMWARE_VERSION=2021.11.21.1
 
 volumes:
   miner-storage:


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Update miner to latest GA 2021.11.21.1

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Bump miner container and version numbers

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://github.com/NebraLtd/hm-miner/commit/31eeca0c7d85eeaa8bac799f943217f5f3541fbd

Relates-to: #255