### PR TITLE
feat: support all i2c buses regardless of device

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,7 @@ services:
       - dbus:/session/dbus
     cap_add:
       - SYS_RAWIO
-    devices:
-      - /dev/i2c-1:/dev/i2c-1
+    privileged: true
     restart: on-failure
     environment:
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
@@ -68,8 +67,7 @@ services:
       - "80:5000"
     cap_add:
       - SYS_RAWIO
-    devices:
-      - /dev/i2c-1:/dev/i2c-1
+    privileged: true
     labels:
       io.balena.features.sysfs: 1
 


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

As per #253 adding /dev/i2c-7 works to enable the i2c on RockPi but stops the diagnostics and miner containers from starting on Raspberry Pi based devices as they have no i2c-7

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

This moves to privileged: true which should give access to all available buses

**References**
<!-- Links to related issues, relevant documentation, etc. -->

#253 