### PR TITLE
fix: revert privileged containers and add rockpi builds

### DIFF
--- a/.github/workflows/push-to-prod.yml
+++ b/.github/workflows/push-to-prod.yml
@@ -5,79 +5,32 @@ on:
     # Only run workflow for pushes to specific branches
     branches:
       - production
+env: 
+  balena-cli: v12.52.1
 
 jobs:
-  outdoor-868:
+  build-prod:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sbc: [raspi, rockpi]
+        frequency: [470, 868, 915]
+        variant: [indoor, outdoor]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Change i2c bus for RockPi
+        if: matrix.sbc == rockpi
+        run: |
+          sed -i -E "s/\/dev\/i2c-1:\/dev\/i2c-1/\/dev\/i2c-7:\/dev\/i2c-7/g" docker-compose.yml
+          ROCKPI="-rockpi"
+          echo "ROCKPI=$ROCKPI" >> $GITHUB_ENV
       - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
+        uses: nebraltd/balena-cli-action@${{ env.balena-cli }}
         if: success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-outdoor-868 --logs --debug --nocache --build"
-
-  indoor-868:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
-        if: success()
-        with:
-          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-indoor-868 --logs --debug --nocache --build"
-
-  outdoor-915:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
-        if: success()
-        with:
-          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-outdoor-915 --logs --debug --nocache --build"
-
-  indoor-915:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
-        if: success()
-        with:
-          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-indoor-915 --logs --debug --nocache --build"
-
-  outdoor-470:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
-        if: success()
-        with:
-          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-outdoor-470 --logs --debug --nocache --build"
-
-  indoor-470:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
-        if: success()
-        with:
-          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-indoor-470 --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }}${{ env.ROCKPI }} --logs --debug --nocache --build"
 
   open-fleet:
     runs-on: ubuntu-latest
@@ -85,7 +38,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
+        uses: nebraltd/balena-cli-action@${{ env.balena-cli }}
         if: success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
@@ -97,7 +50,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
+        uses: nebraltd/balena-cli-action@${{ env.balena-cli }}
         if: success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}

--- a/.github/workflows/push-to-prod.yml
+++ b/.github/workflows/push-to-prod.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - production
 
-env: 
-  balena-cli: v12.52.1
-
 jobs:
   build-prod:
     runs-on: ubuntu-latest
@@ -27,7 +24,7 @@ jobs:
           ROCKPI="-rockpi"
           echo "ROCKPI=$ROCKPI" >> $GITHUB_ENV
       - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@${{ env.balena-cli }}
+        uses: nebraltd/balena-cli-action@v12.54.5
         if: success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
@@ -39,7 +36,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@${{ env.balena-cli }}
+        uses: nebraltd/balena-cli-action@v12.54.5
         if: success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
@@ -51,7 +48,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@${{ env.balena-cli }}
+        uses: nebraltd/balena-cli-action@v12.54.5
         if: success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}

--- a/.github/workflows/push-to-prod.yml
+++ b/.github/workflows/push-to-prod.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Change i2c bus for RockPi
-        if: matrix.sbc == rockpi
+        if: matrix.sbc == 'rockpi'
         run: |
           sed -i -E "s/\/dev\/i2c-1:\/dev\/i2c-1/\/dev\/i2c-7:\/dev\/i2c-7/g" docker-compose.yml
           ROCKPI="-rockpi"

--- a/.github/workflows/push-to-prod.yml
+++ b/.github/workflows/push-to-prod.yml
@@ -5,6 +5,7 @@ on:
     # Only run workflow for pushes to specific branches
     branches:
       - production
+
 env: 
   balena-cli: v12.52.1
 

--- a/.github/workflows/push-to-testnet.yml
+++ b/.github/workflows/push-to-testnet.yml
@@ -6,15 +6,27 @@ on:
     branches:
       - master
 
+env: 
+  balena-cli: v12.52.1
+
 jobs:
   testnet:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        sbc: [raspi, rockpi]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Change i2c bus for RockPi
+        if: matrix.sbc == rockpi
+        run: |
+          sed -i -E "s/\/dev\/i2c-1:\/dev\/i2c-1/\/dev\/i2c-7:\/dev\/i2c-7/g" docker-compose.yml
+          ROCKPI="-rockpi"
+          echo "ROCKPI=$ROCKPI" >> $GITHUB_ENV
       - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@v12.51.1
+        uses: nebraltd/balena-cli-action@${{ env.balena-cli }}
         if: success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-testnet --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-testnet${{ env.ROCKPI }} --logs --debug --nocache --build"

--- a/.github/workflows/push-to-testnet.yml
+++ b/.github/workflows/push-to-testnet.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Change i2c bus for RockPi
-        if: matrix.sbc == rockpi
+        if: matrix.sbc == 'rockpi'
         run: |
           sed -i -E "s/\/dev\/i2c-1:\/dev\/i2c-1/\/dev\/i2c-7:\/dev\/i2c-7/g" docker-compose.yml
           ROCKPI="-rockpi"

--- a/.github/workflows/push-to-testnet.yml
+++ b/.github/workflows/push-to-testnet.yml
@@ -6,9 +6,6 @@ on:
     branches:
       - master
 
-env: 
-  balena-cli: v12.52.1
-
 jobs:
   testnet:
     runs-on: ubuntu-latest
@@ -25,7 +22,7 @@ jobs:
           ROCKPI="-rockpi"
           echo "ROCKPI=$ROCKPI" >> $GITHUB_ENV
       - name: Balena Deploy
-        uses: nebraltd/balena-cli-action@${{ env.balena-cli }}
+        uses: nebraltd/balena-cli-action@v12.54.5
         if: success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,7 +50,8 @@ services:
       - dbus:/session/dbus
     cap_add:
       - SYS_RAWIO
-    privileged: true
+    devices:
+      - /dev/i2c-1:/dev/i2c-1
     restart: on-failure
     environment:
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
@@ -67,7 +68,8 @@ services:
       - "80:5000"
     cap_add:
       - SYS_RAWIO
-    privileged: true
+    devices:
+      - /dev/i2c-1:/dev/i2c-1
     labels:
       io.balena.features.sysfs: 1
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     stop_signal: SIGINT
 
   packet-forwarder:
-    image: nebraltd/hm-pktfwd:e067bef
+    image: nebraltd/hm-pktfwd:8d8de7d
     depends_on:
       - helium-miner
     restart: always

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.21.2
+      - FIRMWARE_VERSION=2021.11.21.2-1
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -58,9 +58,9 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:7e26f35
+    image: nebraltd/hm-diag:b30bd8a
     environment:
-      - FIRMWARE_VERSION=2021.11.21.2
+      - FIRMWARE_VERSION=2021.11.21.2-1
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data
@@ -87,7 +87,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.11.21.2
+      - FIRMWARE_VERSION=2021.11.21.2-1
 
 volumes:
   miner-storage:


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

- revert privileged containers
- add rockpi builds
- make actions easier to read and maintain using strategy matrix in builds
- sx1302 fixes

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

- revert privileged containers based on discussion in #253
- add rockpi builds to testnet and production actions using build matrix
- with rockpi versions, change the i2c bus to i2c-7 in docker-compose
- remove hard coded balena cli version and change to env variable
- bump pktfwd to bring in sx1302 fixes

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Relates-to: #253 
Relates-to: https://github.com/NebraLtd/hm-diag/issues/237
Relates-to: https://github.com/NebraLtd/hm-pyhelper/pull/68
Relates-to: https://github.com/NebraLtd/hm-pktfwd/pull/74
Relates-to: https://github.com/NebraLtd/hm-pktfwd/pull/72
Relates-to: https://github.com/NebraLtd/hm-pktfwd/issues/70