### PR TITLE
fix(diagnostics): expose serial-number

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.22.0-1
+      - FIRMWARE_VERSION=2021.11.22.0-2
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -59,7 +59,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:b30bd8a
     environment:
-      - FIRMWARE_VERSION=2021.11.22.0-1
+      - FIRMWARE_VERSION=2021.11.22.0-2
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data
@@ -70,6 +70,7 @@ services:
     privileged: true
     labels:
       io.balena.features.sysfs: 1
+      io.balena.features.procfs: 1
 
   upnp:
     image: nebraltd/hm-upnp:b575a2f
@@ -85,7 +86,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.11.22.0-1
+      - FIRMWARE_VERSION=2021.11.22.0-2
 
 volumes:
   miner-storage:


### PR DESCRIPTION
**Why**
As a hotspot owner, I want to be able to access the serial-number.

**How**
Added label `io.balena.features.procfs` to diagnostics.

**References**
- Builds off: https://github.com/NebraLtd/hm-diag/pull/219