### PR TITLE
Use port 7000 to resolve response delay issues in hm-diag.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -64,7 +64,7 @@ services:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data
     ports:
-      - "80:5000"
+      - "80:7000"
     cap_add:
       - SYS_RAWIO
     privileged: true


### PR DESCRIPTION
gunicorn running on port 5000 for hm-diag was causing delays in minutes for endpoint responses. See [hm-diag#248](https://github.com/NebraLtd/hm-diag/issues/248) for the full discussion. Switching to a different port resolves this issue.