### PR TITLE
Version bump for hm-diag and inclusion of DIAGNOSTICS_VERSION

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.22.0-1
+      - FIRMWARE_VERSION=2021.11.26.1
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -59,7 +59,7 @@ services:
   diagnostics:
     image: nebraltd/hm-diag:3e478a9
     environment:
-      - FIRMWARE_VERSION=2021.11.22.0-1
+      - FIRMWARE_VERSION=2021.11.26.1
       - DIAGNOSTICS_VERSION=3e478a9
     volumes:
       - pktfwdr:/var/pktfwd
@@ -86,7 +86,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.11.22.0-1
+      - FIRMWARE_VERSION=2021.11.26.1
 
 volumes:
   miner-storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,9 +57,10 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:b30bd8a
+    image: nebraltd/hm-diag:3e478a9
     environment:
       - FIRMWARE_VERSION=2021.11.22.0-1
+      - DIAGNOSTICS_VERSION=3e478a9
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data


### PR DESCRIPTION
Added env var DIAGNOSTICS_VERSION to hold hm-diag git hash and updated hm-diag git hash to point to a commit that contains operational /version endpoint

**Why**
To allow the new `/version` endpoint in hm-diag to work.

**How**
Added DIAGNOSTICS_VERSION environment variable in docker-compose.yml that points to current hm-diag git hash. This is ready by the view for `/version` in hm-diag and returned as a json response.

