### PR TITLE
feat(diagnostics): better detect BT devices and LTE devices

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -62,7 +62,7 @@ services:
       - dbus-session
     environment:
       - FIRMWARE_VERSION=2021.11.26.1
-      - DIAGNOSTICS_VERSION=3e478a9
+      - DIAGNOSTICS_VERSION=625ea72
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,17 +58,13 @@ services:
 
   diagnostics:
     image: nebraltd/hm-diag:625ea72
-    depends_on:
-      - dbus-session
     environment:
       - FIRMWARE_VERSION=2021.11.26.1-1
       - DIAGNOSTICS_VERSION=625ea72
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
-      - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data
-      - dbus:/session/dbus
     ports:
       - "80:5000"
     cap_add:
@@ -92,7 +88,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.11.26.1
+      - FIRMWARE_VERSION=2021.11.26.1-1
 
 volumes:
   miner-storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.26.1
+      - FIRMWARE_VERSION=2021.11.26.1-1
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -61,7 +61,7 @@ services:
     depends_on:
       - dbus-session
     environment:
-      - FIRMWARE_VERSION=2021.11.26.1
+      - FIRMWARE_VERSION=2021.11.26.1-1
       - DIAGNOSTICS_VERSION=625ea72
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,13 +57,18 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:3e478a9
+    image: nebraltd/hm-diag:625ea72
+    depends_on:
+      - dbus-session
     environment:
       - FIRMWARE_VERSION=2021.11.26.1
       - DIAGNOSTICS_VERSION=3e478a9
+      - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
+      - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data
+      - dbus:/session/dbus
     ports:
       - "80:5000"
     cap_add:
@@ -71,6 +76,7 @@ services:
     privileged: true
     labels:
       io.balena.features.sysfs: 1
+      io.balena.features.dbus: 1
 
   upnp:
     image: nebraltd/hm-upnp:b575a2f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: '2'
 services:
 
   gateway-config:
-    image: nebraltd/hm-config:e0c6f88
+    image: nebraltd/hm-config:8cc544f
     depends_on:
       - dbus-session
       - diagnostics


### PR DESCRIPTION
**Why**
Detect the BLE and LET devices in better way.

**How**
To get the BLE devices and LTE devices programatically using dbus, enable the dbus feature in `diagnostics` container.

**References**
https://github.com/NebraLtd/hm-diag/issues/96
https://github.com/NebraLtd/hm-diag/issues/88
https://github.com/NebraLtd/hm-config/issues/46

https://github.com/NebraLtd/hm-config/pull/152
https://github.com/NebraLtd/hm-config/pull/142
https://github.com/NebraLtd/hm-config/pull/141
