### PR TITLE
fix: add fail fast false to matrix workflows

### DIFF
--- a/.github/workflows/push-to-prod.yml
+++ b/.github/workflows/push-to-prod.yml
@@ -10,6 +10,7 @@ jobs:
   build-prod:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         sbc: [raspi, rockpi]
         frequency: [470, 868, 915]

--- a/.github/workflows/push-to-testnet.yml
+++ b/.github/workflows/push-to-testnet.yml
@@ -10,6 +10,7 @@ jobs:
   testnet:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         sbc: [raspi, rockpi]
     steps:


### PR DESCRIPTION
**Why**
<!-- What is the objective of this work? -->

Allow some jobs to build even if some fail

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

add fail fast false

**References**
<!-- Links to related issues, relevant documentation, etc. -->

https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#jobsjob_idstrategyfail-fast