### PR TITLE
fix: display Miner RPC/Helium API availability correctly

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.30.1
+      - FIRMWARE_VERSION=2021.11.30.1-1
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -58,10 +58,10 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:72f141f
+    image: nebraltd/hm-diag:68d4984
     environment:
-      - FIRMWARE_VERSION=2021.11.30.1
-      - DIAGNOSTICS_VERSION=72f141f
+      - FIRMWARE_VERSION=2021.11.30.1-1
+      - DIAGNOSTICS_VERSION=68d4984
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
     volumes:
       - pktfwdr:/var/pktfwd
@@ -92,7 +92,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.11.30.1
+      - FIRMWARE_VERSION=2021.11.30.1-1
 
 volumes:
   miner-storage:


### PR DESCRIPTION
**Why**
As a diagnostics user, I should be able to clearly differentiate miner errors from Helium API errors so that I have a better sense of what is going wrong.

**How**
Sync Percentage: Add Miner RPC Unavailable
Sync Percentage: Rename Helium API Not Available to Helium API Unavailable
Height Status: Rename Not Available to Miner RPC Unavailable
Height Status: Add Helium API Unavailable.

**References**
https://github.com/NebraLtd/hm-diag/issues/235