### PR TITLE
Hotfixing hm-diag#264 and including the new diagnostics hash

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.11.30.1-1
+      - FIRMWARE_VERSION=2021.11.30.1-2
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -58,10 +58,10 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:68d4984
+    image: nebraltd/hm-diag:c22a429
     environment:
-      - FIRMWARE_VERSION=2021.11.30.1-1
-      - DIAGNOSTICS_VERSION=68d4984
+      - FIRMWARE_VERSION=2021.11.30.1-2
+      - DIAGNOSTICS_VERSION=c22a429
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
     volumes:
       - pktfwdr:/var/pktfwd
@@ -92,7 +92,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.11.30.1-1
+      - FIRMWARE_VERSION=2021.11.30.1-2
 
 volumes:
   miner-storage:


### PR DESCRIPTION
**Issue**
Fixes the issue where `provision_key` was never getting called.
- Link: https://github.com/NebraLtd/hm-diag/issues/264
