### PR TITLE
feat: add manual draft balena deploy action

### DIFF
--- a/.github/workflows/push-to-prod-draft.yml
+++ b/.github/workflows/push-to-prod-draft.yml
@@ -1,0 +1,59 @@
+name: BalenaCloud Deploy (Production - Draft Deploy)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build-prod:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sbc: [raspi, rockpi]
+        frequency: [470, 868, 915]
+        variant: [indoor, outdoor]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: production
+      - name: Change i2c bus for RockPi
+        if: matrix.sbc == 'rockpi'
+        run: |
+          sed -i -E "s/\/dev\/i2c-1:\/dev\/i2c-1/\/dev\/i2c-7:\/dev\/i2c-7/g" docker-compose.yml
+          ROCKPI="-rockpi"
+          echo "ROCKPI=$ROCKPI" >> $GITHUB_ENV
+      - name: Balena Deploy
+        uses: nebraltd/balena-cli-action@v12.54.5
+        if: success()
+        with:
+          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
+          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }}${{ env.ROCKPI }} --logs --debug --nocache --build --draft"
+
+  open-fleet:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: production
+      - name: Balena Deploy
+        uses: nebraltd/balena-cli-action@v12.54.5
+        if: success()
+        with:
+          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
+          balena_command: "deploy nebraltd/helium-miner --logs --debug --nocache --build --draft"
+
+  commercial:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          ref: production
+      - name: Balena Deploy
+        uses: nebraltd/balena-cli-action@v12.54.5
+        if: success()
+        with:
+          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
+          balena_command: "deploy nebraltd/helium-miner-commercial --logs --debug --nocache --build --draft"

--- a/.github/workflows/push-to-testnet-draft.yml
+++ b/.github/workflows/push-to-testnet-draft.yml
@@ -1,0 +1,27 @@
+name: BalenaCloud Deploy (Testnet - Draft Deploy)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  testnet:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sbc: [raspi, rockpi]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Change i2c bus for RockPi
+        if: matrix.sbc == 'rockpi'
+        run: |
+          sed -i -E "s/\/dev\/i2c-1:\/dev\/i2c-1/\/dev\/i2c-7:\/dev\/i2c-7/g" docker-compose.yml
+          ROCKPI="-rockpi"
+          echo "ROCKPI=$ROCKPI" >> $GITHUB_ENV
+      - name: Balena Deploy
+        uses: nebraltd/balena-cli-action@v12.54.5
+        if: success()
+        with:
+          balena_api_token: ${{secrets.BALENA_API_TOKEN}}
+          balena_command: "deploy nebraltd/helium-testnet${{ env.ROCKPI }} --logs --debug --nocache --build --draft"

--- a/README.md
+++ b/README.md
@@ -88,6 +88,18 @@ the [production branch](https://github.com/NebraLtd/helium-miner-software/tree/p
 
 Do note that the Docker Tag is hard coded in the `docker-compose.yml` file.
 
+## Dealing with failed builds
+
+On occasion (as originally described [in this issue](https://github.com/NebraLtd/helium-miner-software/issues/293)) CI/CD builds via GitHub actions will fail to push correctly to balena. We have found that as a workaround, it is often possible to force push these to balena as draft releases using the `--draft` tag in the `balena deploy` command of the balena CLI tool. For example:
+
+```
+balena deploy nebraltd/helium-indoor-868 --logs --debug --nocache --build --draft
+```
+
+This can either be done manually by someone with the right privileges on our balenaCloud account, or it can be done by triggering the `workflow_dispatch:` event on the [push-to-prod-draft.yml github action](https://github.com/NebraLtd/helium-miner-software/blob/master/.github/workflows/push-to-prod-draft.yml) from the GitHub actions menu (making sure to use the production branch). 
+
+Once this has completed and the draft builds have been pushed to balena, you will need to either finalise the releases using balena CLI locally, or visit the releases menu of each fleet with a draft release, click on the release and then select `Finalize Release` from the dropdown menu.
+
 # Production Checks
 
 @TODO:


### PR DESCRIPTION
**Issue**

- Link: #293
- Summary: draft builds allow us sometimes to push through failed builds when balena having issues.

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Add new manually triggerable action to allow us to push draft builds to balena and then manually finalise them from balenaCloud

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Relates-to: #293

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names