### PR TITLE
release(testnet): initFile uses new BT/LTE logic

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.12.14.0-1
+      - FIRMWARE_VERSION=2021.12.14.0-2
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -58,9 +58,9 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:4ab18f4
+    image: nebraltd/hm-diag:e59ca4f
     environment:
-      - FIRMWARE_VERSION=2021.12.14.0-1
+      - FIRMWARE_VERSION=2021.12.14.0-2
       - DIAGNOSTICS_VERSION=c22a429
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
     volumes:
@@ -92,7 +92,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.12.14.0-1
+      - FIRMWARE_VERSION=2021.12.14.0-2
 
 volumes:
   miner-storage:


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-diag/issues/252
- Summary: initFile was using out-of-date logic for BT/LTE detection. Diagnostics page (/json endpoint) was using updated logic, but manufacturing (/initFile.txt endpoint) thought BT was failing on ROCK Pis.

**How**
Copy /json logic to /initFile

**References**
- Related to: https://github.com/NebraLtd/hm-diag/pull/272
- Related to: https://github.com/NebraLtd/hm-config/issues/156

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names