### PR TITLE
feat: bump diag to bring in hm-pyhelper updates

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
       - dbus-session
       - diagnostics
     environment:
-      - FIRMWARE_VERSION=2021.12.14.0-4
+      - FIRMWARE_VERSION=2021.12.14.0-5
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
       - DBUS_SESSION_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
     privileged: true
@@ -58,9 +58,9 @@ services:
       - RELEASE_BUMPER=foobar
 
   diagnostics:
-    image: nebraltd/hm-diag:1735292
+    image: nebraltd/hm-diag:86fa294
     environment:
-      - FIRMWARE_VERSION=2021.12.14.0-4
+      - FIRMWARE_VERSION=2021.12.14.0-5
       - DIAGNOSTICS_VERSION=c22a429
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/host/run/dbus/system_bus_socket
     volumes:
@@ -92,7 +92,7 @@ services:
       - dbus:/session/dbus
     environment:
       - DBUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
-      - FIRMWARE_VERSION=2021.12.14.0-4
+      - FIRMWARE_VERSION=2021.12.14.0-5
 
 volumes:
   miner-storage:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -56,6 +56,7 @@ services:
     environment:
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
       - RELEASE_BUMPER=foobar
+      - FIRMWARE_VERSION=2021.12.14.0-5
 
   diagnostics:
     image: nebraltd/hm-diag:86fa294


### PR DESCRIPTION
**Issue**

- Link: N/A
- Summary: i2c ECC bus missing from hardware details

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

Bump diag container

Also adds firmware version to number container so it restarts on every new release.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

Relates to https://github.com/NebraLtd/hm-diag/pull/277
Relates to https://github.com/NebraLtd/hm-pyhelper/pull/84
Related to https://github.com/NebraLtd/hm-config/issues/162

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names