### PR TITLE
Added privileged: true to diag container

### DIFF
--- a/templates/docker-compose.template
+++ b/templates/docker-compose.template
@@ -74,6 +74,7 @@ services:
       - SYS_RAWIO
     devices:
       - {{I2C_DEVICE}}:{{I2C_DEVICE}}
+    privileged: true
     labels:
       io.balena.features.sysfs: 1
       io.balena.features.procfs: 1


### PR DESCRIPTION
**Issue**

- Link: #343 
- Summary: Diagnostics container missing /proc/device-tree file structure resulting in diagnostics page to not load

**How**
Jinja2 template was missing ```privileged: true``` to allow the container to access system level files, this was added to the template

Closes: #343 