### PR TITLE
feat: bump OG balena.yml to add raspberrypi3-64

### DIFF
--- a/balena/balena.yml.og
+++ b/balena/balena.yml.og
@@ -27,4 +27,5 @@ data:
   defaultDeviceType: raspberrypi4-64
   supportedDeviceTypes:
     - raspberrypi4-64
-version: 0.0.1
+    - raspberrypi3-64
+version: 0.0.2


### PR DESCRIPTION
**Issue**

- Link: #397 
- Summary: Helium OG miner can be raspberry pi 3

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

As per #397 some original helium hotspots use raspberry pi 3 so this PR adds ability to add a Pi3-64bit on the balena openfleet

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

#397 

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names