### PR TITLE
fix: Add host networking to hm-miner to access grpc api #427

### DIFF
--- a/templates/docker-compose.template
+++ b/templates/docker-compose.template
@@ -27,6 +27,10 @@ services:
       - helium-miner
     restart: always
     privileged: true
+    network_mode: host
+    # host networking doesn't export hostnames
+    extra_hosts:
+        - "helium-miner:127.0.0.1"
     volumes:
       - pktfwdr:/var/pktfwd
     environment:
@@ -34,9 +38,7 @@ services:
 
   helium-miner:
     image: nebraltd/hm-gatewayrs:{{GATEWAY_VERSION}}
-    expose:
-      - "1680"
-      - "4467"
+    network_mode: host
     cap_add:
       - SYS_RAWIO
     devices:
@@ -61,8 +63,10 @@ services:
     volumes:
       - pktfwdr:/var/pktfwd
       - miner-storage:/var/data
-    ports:
-      - "80:5000"
+    network_mode: host
+    # host networking doesn't export hostnames
+    extra_hosts:
+        - "helium-miner:127.0.0.1"
     cap_add:
       - SYS_RAWIO
     devices:
@@ -80,3 +84,13 @@ services:
 volumes:
   miner-storage:
   pktfwdr:
+
+# balena keeps on changing the subnet, making it impossible
+# to use extra_hosts for naming host IPs
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+        - subnet: 172.20.0.0/16


### PR DESCRIPTION
**[Issue](https://github.com/NebraLtd/helium-miner-software/issues/427)**

- Link: https://github.com/NebraLtd/helium-miner-software/issues/427
- Summary: gateway-rs listens only on local host. Only way to make diag work at this stage is to use host networking.

**How**
- helium-miner and diagnostics use host networking

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [x] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names