### PR TITLE
Add Github short hash to all services

### DIFF
--- a/templates/docker-compose.template
+++ b/templates/docker-compose.template
@@ -35,6 +35,7 @@ services:
       - pktfwdr:/var/pktfwd
     environment:
       - FIRMWARE_VERSION={{FIRMWARE_VERSION}}
+      - FIRMWARE_SHORT_HASH={{ENV.FIRMWARE_SHORT_HASH}}
 
   helium-miner:
     image: nebraltd/hm-miner:{{ARCH}}-{{MINER_VERSION}}
@@ -59,6 +60,7 @@ services:
     environment:
       - DBUS_SYSTEM_BUS_ADDRESS=unix:path=/session/dbus/session_bus_socket
       - FIRMWARE_VERSION={{FIRMWARE_VERSION}}
+      - FIRMWARE_SHORT_HASH={{ENV.FIRMWARE_SHORT_HASH}}
 
   diagnostics:
     image: nebraltd/hm-diag:{{DIAGNOSTICS_VERSION}}


### PR DESCRIPTION
**Issue**

- Link: https://github.com/NebraLtd/hm-diag/issues/352
- Summary:
There are many Sentry issues related with "gateway_mfr exited with a non-zero status" in `hm-diag`.
This is most likely happening if not all services get restarted when we release a new version to the Balena fleets.
As a convention, we update the `FIRMWARE_VERSION` in the `settings.ini` in the every version update so that all services restart, but if we forget to update `FIRMWARE_VERSION`, then it is the case that only some services will restart.

It would be safer and better solution to add `FIRMWARE_SHORT_HASH` to the environment variable of all the services since its value is generated automatically on every release.

**How**
Add `FIRMWARE_SHORT_HASH` environment variable to `packet-forwarder` and `helium-miner` service. 
The other services already contain this environment variable.

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names