### PR TITLE
fix: latest balena-cli removed --logs option

### DIFF
--- a/.github/workflows/push-to-prod-draft.yml
+++ b/.github/workflows/push-to-prod-draft.yml
@@ -122,31 +122,31 @@ jobs:
         if: matrix.sbc == 'rockpi' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }}${{ env.ROCKPI }} --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }}${{ env.ROCKPI }} --debug --nocache --build --draft"
       - name: Balena Deploy (Nebra RasPi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: matrix.sbc == 'raspi' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_1}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }} --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }} --debug --nocache --build --draft"
       - name: Balena Deploy (RAK and Non-Nebra RasPi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: ( matrix.sbc == 'rak' || matrix.sbc == 'og' || matrix.sbc == 'sensecap' || matrix.sbc == 'finestra' || matrix.sbc == 'controllino' || matrix.sbc == 'cotx' || matrix.sbc == 'pantherx1' || matrix.sbc == 'linxdot' || matrix.sbc == 'syncrobit' || matrix.sbc == 'pycom' || matrix.sbc == 'risinghf' ) && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_2}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --debug --nocache --build --draft"
       - name: Balena Deploy (Non-Nebra ROCK Pi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: ( matrix.sbc == 'linxdot-rkcm3' || matrix.sbc == 'syncrobit-rkcm3' ) && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_3}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --debug --nocache --build --draft"
       - name: Balena Deploy (Pisces P100)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: matrix.sbc == 'pisces' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_4}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --debug --nocache --build --draft"
       - name: Trigger build action in helium-${{ matrix.sbc }} repo
         uses: peter-evans/repository-dispatch@v1
         if: ( matrix.sbc == 'rak' || matrix.sbc == 'pisces' || matrix.sbc == 'og' || matrix.sbc == 'sensecap' || matrix.sbc == 'finestra' || matrix.sbc == 'controllino' || matrix.sbc == 'cotx' || matrix.sbc == 'pantherx1' || matrix.sbc == 'linxdot' || matrix.sbc == 'linxdot-rkcm3' || matrix.sbc == 'syncrobit' || matrix.sbc == 'syncrobit-rkcm3' || matrix.sbc == 'pycom' || matrix.sbc == 'risinghf' ) && success()

--- a/.github/workflows/push-to-prod.yml
+++ b/.github/workflows/push-to-prod.yml
@@ -123,31 +123,31 @@ jobs:
         if: matrix.sbc == 'rockpi' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }}${{ env.ROCKPI }} --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }}${{ env.ROCKPI }} --debug --nocache --build"
       - name: Balena Deploy (Nebra RasPi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: matrix.sbc == 'raspi' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_1}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }} --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-${{ matrix.variant }}-${{ matrix.frequency }} --debug --nocache --build"
       - name: Balena Deploy (RAK and Non-Nebra RasPi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: ( matrix.sbc == 'rak' || matrix.sbc == 'og' || matrix.sbc == 'sensecap' || matrix.sbc == 'finestra' || matrix.sbc == 'controllino' || matrix.sbc == 'cotx' || matrix.sbc == 'pantherx1' || matrix.sbc == 'linxdot' || matrix.sbc == 'syncrobit' || matrix.sbc == 'pycom' || matrix.sbc == 'risinghf') && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_2}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --debug --nocache --build"
       - name: Balena Deploy (Non-Nebra ROCK Pi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: ( matrix.sbc == 'linxdot-rkcm3' || matrix.sbc == 'syncrobit-rkcm3' ) && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_3}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --debug --nocache --build"
       - name: Balena Deploy (Pisces P100)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: matrix.sbc == 'pisces' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_4}}
-          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-${{ matrix.sbc }} --debug --nocache --build"
       - name: Trigger build action in helium-${{ matrix.sbc }} repo
         uses: peter-evans/repository-dispatch@v1
         if: ( matrix.sbc == 'rak' || matrix.sbc == 'pisces' || matrix.sbc == 'og' || matrix.sbc == 'sensecap' || matrix.sbc == 'finestra' || matrix.sbc == 'controllino' || matrix.sbc == 'cotx' || matrix.sbc == 'pantherx1' || matrix.sbc == 'linxdot' || matrix.sbc == 'linxdot-rkcm3' || matrix.sbc == 'syncrobit' || matrix.sbc == 'syncrobit-rkcm3' || matrix.sbc == 'pycom' || matrix.sbc == 'risinghf' ) && success()

--- a/.github/workflows/push-to-testnet-draft.yml
+++ b/.github/workflows/push-to-testnet-draft.yml
@@ -41,25 +41,25 @@ jobs:
         if: matrix.sbc == 'rockpi' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN}}
-          balena_command: "deploy nebraltd/helium-testnet${{ env.ROCKPI }} --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-testnet${{ env.ROCKPI }} --debug --nocache --build --draft"
       - name: Balena Deploy (Nebra RasPi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: matrix.sbc == 'raspi' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_1}}
-          balena_command: "deploy nebraltd/helium-testnet --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-testnet --debug --nocache --build --draft"
       - name: Balena Deploy (RAK and other non-Nebra RasPi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: success() && (matrix.sbc == 'rak' || matrix.sbc == 'og' || matrix.sbc == 'sensecap' || matrix.sbc == 'finestra' || matrix.sbc == 'controllino' || matrix.sbc == 'pisces' || matrix.sbc == 'cotx' || matrix.sbc == 'pantherx1' || matrix.sbc == 'linxdot' || matrix.sbc == 'syncrobit' || matrix.sbc == 'pycom' || matrix.sbc == 'risinghf')
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_2}}
-          balena_command: "deploy nebraltd/helium-testnet-${{ matrix.sbc }} --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-testnet-${{ matrix.sbc }} --debug --nocache --build --draft"
       - name: Balena Deploy (Non-Nebra ROCK Pi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: success() && (matrix.sbc == 'linxdot-rkcm3' || matrix.sbc == 'syncrobit-rkcm3')
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_3}}
-          balena_command: "deploy nebraltd/helium-testnet-${{ matrix.sbc }} --logs --debug --nocache --build --draft"
+          balena_command: "deploy nebraltd/helium-testnet-${{ matrix.sbc }} --debug --nocache --build --draft"
       - name: Push updated docker compose file (ROCK Pi)
         if: (matrix.sbc == 'rockpi' || matrix.sbc == 'linxdot-rkcm3' || matrix.sbc == 'syncrobit-rkcm3') && success()
         uses: test-room-7/action-update-file@v1

--- a/.github/workflows/push-to-testnet.yml
+++ b/.github/workflows/push-to-testnet.yml
@@ -52,19 +52,19 @@ jobs:
         if: matrix.sbc == 'raspi' && success()
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_1}}
-          balena_command: "deploy nebraltd/helium-testnet --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-testnet --debug --nocache --build"
       - name: Balena Deploy (RAK and other non-Nebra RasPi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: success() && (matrix.sbc == 'rak' || matrix.sbc == 'og' || matrix.sbc == 'sensecap' || matrix.sbc == 'finestra' || matrix.sbc == 'controllino' || matrix.sbc == 'pisces' || matrix.sbc == 'cotx' || matrix.sbc == 'pantherx1' || matrix.sbc == 'linxdot' || matrix.sbc == 'syncrobit' || matrix.sbc == 'pycom' || matrix.sbc == 'risinghf')
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_2}}
-          balena_command: "deploy nebraltd/helium-testnet-${{ matrix.sbc }} --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-testnet-${{ matrix.sbc }} --debug --nocache --build"
       - name: Balena Deploy (Non-Nebra ROCK Pi)
         uses: nebraltd/balena-cli-action@v14.5.15
         if: success() && (matrix.sbc == 'linxdot-rkcm3' || matrix.sbc == 'syncrobit-rkcm3')
         with:
           balena_api_token: ${{secrets.BALENA_API_TOKEN_3}}
-          balena_command: "deploy nebraltd/helium-testnet-${{ matrix.sbc }} --logs --debug --nocache --build"
+          balena_command: "deploy nebraltd/helium-testnet-${{ matrix.sbc }} --debug --nocache --build"
       - name: Push updated docker compose file (ROCK Pi)
         if: (matrix.sbc == 'rockpi' || matrix.sbc == 'linxdot-rkcm3' || matrix.sbc == 'syncrobit-rkcm3') && success()
         uses: test-room-7/action-update-file@v1


### PR DESCRIPTION
latest balena-cli removed --logs option (now defaults to having logs and turn off with --nologs)

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names