### PR TITLE
fix: bump checkout to v3 for all actions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -36,7 +36,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           # Full git history is needed to get a proper list of changed files within `super-linter`
           fetch-depth: 0

--- a/.github/workflows/push-to-prod-draft.yml
+++ b/.github/workflows/push-to-prod-draft.yml
@@ -72,7 +72,7 @@ jobs:
             frequency: 868
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           ref: production
       - name: Export short SHA of current commit

--- a/.github/workflows/push-to-prod.yml
+++ b/.github/workflows/push-to-prod.yml
@@ -75,7 +75,7 @@ jobs:
             frequency: 868
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Export short SHA of current commit
         shell: bash
         run: |

--- a/.github/workflows/push-to-testnet-draft.yml
+++ b/.github/workflows/push-to-testnet-draft.yml
@@ -12,7 +12,7 @@ jobs:
         sbc: [raspi, rockpi, rak, finestra, sensecap, og, controllino, pisces, cotx, pantherx1, linxdot, linxdot-rkcm3, syncrobit, syncrobit-rkcm3, pycom, risinghf]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Export short SHA of current commit
         run: |
           FIRMWARE_SHORT_HASH=$( echo ${GITHUB_SHA:0:7} )

--- a/.github/workflows/push-to-testnet.yml
+++ b/.github/workflows/push-to-testnet.yml
@@ -17,7 +17,7 @@ jobs:
         sbc: [raspi, rockpi, rak, finestra, sensecap, og, controllino, pisces, cotx, pantherx1, linxdot, linxdot-rkcm3, syncrobit, syncrobit-rkcm3, pycom, risinghf]
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Export short SHA of current commit
         run: |
           FIRMWARE_SHORT_HASH=$( echo ${GITHUB_SHA:0:7} )

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python 3.8
       uses: actions/setup-python@v1
       with:

--- a/.github/workflows/update-miner.yml
+++ b/.github/workflows/update-miner.yml
@@ -6,7 +6,7 @@ jobs:
   miner-update:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: 
           ref: ${{ github.ref }}
       - run: |

--- a/.github/workflows/update-production.yml
+++ b/.github/workflows/update-production.yml
@@ -10,7 +10,7 @@ jobs:
     if: github.event.pull_request.merged == true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: 
           ref: ${{ github.ref }}
           fetch-depth: 0

--- a/balena/workflows/build-open-fleet.yml
+++ b/balena/workflows/build-open-fleet.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: 
           ref: master
 

--- a/balena/workflows/update-files.yml
+++ b/balena/workflows/update-files.yml
@@ -7,7 +7,7 @@ jobs:
   file-update-prod:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: 
           ref: master
       - run: |
@@ -64,7 +64,7 @@ jobs:
   file-update-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with: 
           ref: testnet
       - run: |


### PR DESCRIPTION
bump checkout to v3 for all actions (see https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/ for info)

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [x] Tests added
- [x] Cleaned up commit history (rebase!)
- [x] Documentation added
- [x] Thought about variable and method names