### PR TITLE
fix: remove duplicate modem info

### DIFF
--- a/settings.ini
+++ b/settings.ini
@@ -14,10 +14,6 @@ MODEM_SERIAL3=/dev/ttyUSB3
 [device_rpi]
 ARCH=arm64
 I2C_DEVICE=/dev/i2c-1
-MODEM_SERIAL0=/dev/ttyUSB0
-MODEM_SERIAL1=/dev/ttyUSB1
-MODEM_SERIAL2=/dev/ttyUSB2
-MODEM_SERIAL3=/dev/ttyUSB3
 
 [device_rockpi]
 ARCH=arm64


### PR DESCRIPTION
It seems that this modem info was accidentally duplicated here at some point. It is only needed in the Quectel modem part

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names