### PR TITLE
fix: full repo slug (#696)

### DIFF
--- a/balena/workflows/build-open-fleet.yml
+++ b/balena/workflows/build-open-fleet.yml
@@ -364,4 +364,4 @@ jobs:
         with:
           token: ${{ secrets.MR_BUMP }}
           event-type: build-balena-app
-          repository: ${{ github.event.repository.name }}
+          repository: ${{ github.repository }}


### PR DESCRIPTION
${{ github.repository }} gives full nebraltd/helium-nebra-indoor2 repository name.

${{ github.event.repository.name }} only gives helium-nebra-indoor2 without the nebraltd part

**Issue**

- Link:
- Summary:

**How**
<!-- What steps were taken in this work? -->
<!-- Its encouraged to copy information from other places even if it seems redundant -->

**Screenshots**
<!-- Include images, if possible. -->

**References**
<!-- Links to related issues, relevant documentation, etc. -->

**Checklist**

- [ ] Tests added
- [ ] Cleaned up commit history (rebase!)
- [ ] Documentation added
- [ ] Thought about variable and method names